### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# fluent-plugin-delay-inspector, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-delay-inspector
+
+This is a plugin for [Fluentd](http://fluentd.org)
 
 ## DelayInspectorOutput
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
